### PR TITLE
Fix null-reference exception

### DIFF
--- a/src/FluentAssertions.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/FluentAssertions.Analyzers.Tests/DiagnosticVerifier.cs
@@ -28,6 +28,7 @@ namespace FluentAssertions.Analyzers.Tests
             References = new[]
             {
                 typeof(object), // System.Private.CoreLib
+                typeof(Console), // System
                 typeof(Enumerable), // System.Linq
                 typeof(CSharpCompilation), // Microsoft.CodeAnalysis.CSharp
                 typeof(Compilation), // Microsoft.CodeAnalysis

--- a/src/FluentAssertions.Analyzers.Tests/Tips/SanityTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/SanityTests.cs
@@ -90,5 +90,21 @@ public class TestClass
 
             DiagnosticVerifier.VerifyCSharpDiagnosticUsingAllAnalyzers(source);
         }
+
+        [TestMethod]
+        [Implemented(Reason = "https://github.com/fluentassertions/fluentassertions.analyzers/issues/49")]
+        public void WritingToConsole_ShouldNotThrow()
+        {
+            const string source = @"
+public class TestClass
+{
+    public static void Main()
+    {
+        System.Console.WriteLine();
+    }
+}";
+            
+            DiagnosticVerifier.VerifyCSharpDiagnosticUsingAllAnalyzers(source);
+        }    
     }
 }

--- a/src/FluentAssertions.Analyzers/Utilities/FluentAssertionsAnalyzer.cs
+++ b/src/FluentAssertions.Analyzers/Utilities/FluentAssertionsAnalyzer.cs
@@ -58,6 +58,7 @@ namespace FluentAssertions.Analyzers
             var variableNameExtractor = new VariableNameExtractor(semanticModel);
             expression.Accept(variableNameExtractor);
 
+            if (variableNameExtractor.VariableIdentifierName == null) return null;
             var typeInfo = semanticModel.GetTypeInfo(variableNameExtractor.VariableIdentifierName);
             if (typeInfo.ConvertedType == null) return null;
             if (!ShouldAnalyzeVariableType(typeInfo.ConvertedType)) return null;


### PR DESCRIPTION
closes #49 
When running the analyzers on my project using VS 2017 (version 15.7.4), I encountered two null-reference exceptions. This PR fixes those.