### PR TITLE
Check for no SymbolInfo for variables

### DIFF
--- a/src/FluentAssertions.Analyzers.Tests/Tips/SanityTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/SanityTests.cs
@@ -92,6 +92,22 @@ public class TestClass
         }
 
         [TestMethod]
+        [Implemented(Reason = "https://github.com/fluentassertions/fluentassertions.analyzers/issues/58")]
+        public void StaticWithNameof_ShouldNotThrow()
+        {
+            const string source = @"public class TestClass
+{
+    private static string StaticResult { get; set; }
+
+    public static void Main()
+    {
+        StaticResult = nameof(Main);
+    }
+}";
+            DiagnosticVerifier.VerifyCSharpDiagnosticUsingAllAnalyzers(source);
+        }
+
+        [TestMethod]
         [Implemented(Reason = "https://github.com/fluentassertions/fluentassertions.analyzers/issues/49")]
         public void WritingToConsole_ShouldNotThrow()
         {

--- a/src/FluentAssertions.Analyzers/Utilities/VariableNameExtractor.cs
+++ b/src/FluentAssertions.Analyzers/Utilities/VariableNameExtractor.cs
@@ -53,11 +53,17 @@ namespace FluentAssertions.Analyzers
 
         private bool IsVariable(IdentifierNameSyntax node)
         {
-            // TODO: cleanup
-            if (_semanticModel == null) return true;
+            if (_semanticModel != null)
+            {
+                SymbolInfo info = _semanticModel.GetSymbolInfo(node);
+                if (info.Symbol == null ||
+                    info.Symbol.Kind == SymbolKind.Method ||
+                    info.Symbol.IsStatic)
+                {
+                    return false;
+                }
+            }
 
-            var info = _semanticModel.GetSymbolInfo(node);
-            if (info.Symbol.Kind == SymbolKind.Method || info.Symbol.IsStatic) return false;
             return true;
         }
     }


### PR DESCRIPTION
closes #58
Since SymbolInfo is a struct, there's no need to null check that, however, if the default value is returned then the SymbolInfo.Symbol will be null, causing a NullReferenceException (not sure what about the code seems to trigger it, just trial and error)