### PR TITLE
Fix NullConditionalAssertion false positive

### DIFF
--- a/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace FluentAssertions.Analyzers.Tests.Tips
@@ -25,12 +23,6 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [AssertionDiagnostic("actual.MyList.Where(obj => obj?.ToString() == null).Count().Should().Be(0{0});")]
         [Implemented]
         public void NullConditionalWillStillExecuteTest(string assertion) => VerifyCSharpDiagnosticPass(assertion);
-
-        public void Test()
-        {
-            List<object> list = new List<object>();
-            list.Where(obj => obj?.ToString() is { }).Should();
-        }
 
         private static string Code(string assertion) =>
             new StringBuilder()

--- a/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 using System.Text;
 
 namespace FluentAssertions.Analyzers.Tests.Tips
@@ -12,15 +13,20 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [AssertionDiagnostic("actual.MyProperty?.Should().Be(\"test\"{0});")]
         [AssertionDiagnostic("(actual.MyProperty)?.Should().Be(\"test\"{0});")]
         [AssertionDiagnostic("(actual?.MyProperty)?.Should().Be(\"test\"{0});")]
-        [AssertionDiagnostic("((actual?.MyProperty)?.Should().Be(\"test\"{0})).And.NotBe(\"alternative\");")]
+        [AssertionDiagnostic("actual?.MyProperty.Should().Be(actual?.MyProperty{0});")]
         [Implemented]
         public void NullConditionalMayNotExecuteTest(string assertion) => VerifyCSharpDiagnostic(assertion);
 
         [AssertionDataTestMethod]
         [AssertionDiagnostic("(actual?.MyProperty).Should().Be(\"test\"{0});")]
-        [AssertionDiagnostic("((actual?.MyProperty).Should().Be(\"test\"{0})).And.NotBe(\"alternative\");")]
+        [AssertionDiagnostic("actual.MyProperty.Should().Be(actual?.MyProperty{0});")]
+        [AssertionDiagnostic("actual.MyList.Where(obj => obj?.ToString() is {}).Should().Be(\"test\"{0});")]
         [Implemented]
         public void NullConditionalWillStillExecuteTest(string assertion) => VerifyCSharpDiagnosticPass(assertion);
+
+        public void Test()
+        {
+        }
 
         private static string Code(string assertion) =>
             new StringBuilder()
@@ -38,6 +44,7 @@ namespace FluentAssertions.Analyzers.Tests.Tips
                 .AppendLine("    class MyClass")
                 .AppendLine("    {")
                 .AppendLine("        public string MyProperty { get; set; }")
+                .AppendLine("        public List<object> MyList { get; set; }")
                 .AppendLine("    }")
                 .AppendLine("    class Program")
                 .AppendLine("    {")

--- a/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -14,23 +15,28 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [AssertionDiagnostic("(actual.MyProperty)?.Should().Be(\"test\"{0});")]
         [AssertionDiagnostic("(actual?.MyProperty)?.Should().Be(\"test\"{0});")]
         [AssertionDiagnostic("actual?.MyProperty.Should().Be(actual?.MyProperty{0});")]
+        [AssertionDiagnostic("actual.MyList?.Where(obj => obj?.ToString() == null).Count().Should().Be(0{0});")]
         [Implemented]
         public void NullConditionalMayNotExecuteTest(string assertion) => VerifyCSharpDiagnostic(assertion);
 
         [AssertionDataTestMethod]
         [AssertionDiagnostic("(actual?.MyProperty).Should().Be(\"test\"{0});")]
         [AssertionDiagnostic("actual.MyProperty.Should().Be(actual?.MyProperty{0});")]
-        [AssertionDiagnostic("actual.MyList.Where(obj => obj?.ToString() is {}).Should().Be(\"test\"{0});")]
+        [AssertionDiagnostic("actual.MyList.Where(obj => obj?.ToString() == null).Count().Should().Be(0{0});")]
         [Implemented]
         public void NullConditionalWillStillExecuteTest(string assertion) => VerifyCSharpDiagnosticPass(assertion);
 
         public void Test()
         {
+            List<object> list = new List<object>();
+            list.Where(obj => obj?.ToString() is { }).Should();
         }
 
         private static string Code(string assertion) =>
             new StringBuilder()
                 .AppendLine("using System;")
+                .AppendLine("using System.Collections.Generic;")
+                .AppendLine("using System.Linq;")
                 .AppendLine("using FluentAssertions;using FluentAssertions.Extensions;")
                 .AppendLine("namespace TestNamespace")
                 .AppendLine("{")
@@ -66,7 +72,7 @@ namespace FluentAssertions.Analyzers.Tests.Tips
                 Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
                 Locations = new DiagnosticResultLocation[]
                 {
-                    new DiagnosticResultLocation("Test0.cs", 9, 13)
+                    new DiagnosticResultLocation("Test0.cs", 11, 13)
                 }
             });
     }

--- a/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/NullConditionalAssertionTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
-namespace FluentAssertions.Analyzers.Tests
+namespace FluentAssertions.Analyzers.Tests.Tips
 {
     [TestClass]
     public class NullConditionalAssertionTests
@@ -10,12 +10,20 @@ namespace FluentAssertions.Analyzers.Tests
         [AssertionDiagnostic("actual?.Should().Be(expected{0});")]
         [AssertionDiagnostic("actual?.MyProperty.Should().Be(\"test\"{0});")]
         [AssertionDiagnostic("actual.MyProperty?.Should().Be(\"test\"{0});")]
+        [AssertionDiagnostic("(actual.MyProperty)?.Should().Be(\"test\"{0});")]
+        [AssertionDiagnostic("(actual?.MyProperty)?.Should().Be(\"test\"{0});")]
+        [AssertionDiagnostic("((actual?.MyProperty)?.Should().Be(\"test\"{0})).And.NotBe(\"alternative\");")]
         [Implemented]
-        public void TestAnalyzer(string assertion) => VerifyCSharpDiagnostic(assertion);
+        public void NullConditionalMayNotExecuteTest(string assertion) => VerifyCSharpDiagnostic(assertion);
 
-        private void VerifyCSharpDiagnostic(string assertion)
-        {
-            var code = new StringBuilder()
+        [AssertionDataTestMethod]
+        [AssertionDiagnostic("(actual?.MyProperty).Should().Be(\"test\"{0});")]
+        [AssertionDiagnostic("((actual?.MyProperty).Should().Be(\"test\"{0})).And.NotBe(\"alternative\");")]
+        [Implemented]
+        public void NullConditionalWillStillExecuteTest(string assertion) => VerifyCSharpDiagnosticPass(assertion);
+
+        private static string Code(string assertion) =>
+            new StringBuilder()
                 .AppendLine("using System;")
                 .AppendLine("using FluentAssertions;using FluentAssertions.Extensions;")
                 .AppendLine("namespace TestNamespace")
@@ -40,7 +48,11 @@ namespace FluentAssertions.Analyzers.Tests
                 .AppendLine("}")
                 .ToString();
 
-            DiagnosticVerifier.VerifyCSharpDiagnostic<NullConditionalAssertionAnalyzer>(code, new DiagnosticResult
+        private static void VerifyCSharpDiagnosticPass(string assertion)
+            => DiagnosticVerifier.VerifyCSharpDiagnostic<NullConditionalAssertionAnalyzer>(Code(assertion));
+
+        private static void VerifyCSharpDiagnostic(string assertion)
+            => DiagnosticVerifier.VerifyCSharpDiagnostic<NullConditionalAssertionAnalyzer>(Code(assertion), new DiagnosticResult
             {
                 Id = NullConditionalAssertionAnalyzer.DiagnosticId,
                 Message = NullConditionalAssertionAnalyzer.Message,
@@ -50,6 +62,5 @@ namespace FluentAssertions.Analyzers.Tests
                     new DiagnosticResultLocation("Test0.cs", 9, 13)
                 }
             });
-        }
     }
 }

--- a/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
+++ b/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
@@ -64,8 +64,8 @@ namespace FluentAssertions.Analyzers
         private class ConditionalAccessExpressionVisitor : CSharpSyntaxWalker
         {
             private readonly Stack<bool> _foundConditionalAccess = new();
-
             private bool _foundShouldMethodAfterConditionalAccess;
+
             private bool FoundConditionalAccessInCurrentScope => _foundConditionalAccess.Any() && _foundConditionalAccess.Peek();
 
             public bool CodeSmells => _foundShouldMethodAfterConditionalAccess;

--- a/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
+++ b/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
@@ -78,13 +78,6 @@ namespace FluentAssertions.Analyzers
                 _foundConditionalAccess.Pop();
             }
 
-            public override void VisitParenthesizedExpression(ParenthesizedExpressionSyntax node)
-            {
-                _foundConditionalAccess.Push(false);
-                base.DefaultVisit(node);
-                _foundConditionalAccess.Pop();
-            }
-
             public override void VisitArgumentList(ArgumentListSyntax node)
             {
                 _foundConditionalAccess.Push(false);

--- a/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
+++ b/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
@@ -64,11 +64,11 @@ namespace FluentAssertions.Analyzers
         private class ConditionalAccessExpressionVisitor : CSharpSyntaxWalker
         {
             private readonly Stack<bool> _foundConditionalAccess = new();
-            private bool _foundShouldMethodAfterConditionalAccess;
+            private bool _foundShouldMethodAfterConditionalAccessInCurrentScope;
 
             private bool FoundConditionalAccessInCurrentScope => _foundConditionalAccess.Any() && _foundConditionalAccess.Peek();
 
-            public bool CodeSmells => _foundShouldMethodAfterConditionalAccess;
+            public bool CodeSmells => _foundShouldMethodAfterConditionalAccessInCurrentScope;
 
             public override void VisitConditionalAccessExpression(ConditionalAccessExpressionSyntax node)
             {
@@ -89,7 +89,7 @@ namespace FluentAssertions.Analyzers
             {
                 if (FoundConditionalAccessInCurrentScope && node.Identifier.ValueText == "Should")
                 {
-                    _foundShouldMethodAfterConditionalAccess = true;
+                    _foundShouldMethodAfterConditionalAccessInCurrentScope = true;
                 }
             }
         }

--- a/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
+++ b/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
@@ -64,11 +64,11 @@ namespace FluentAssertions.Analyzers
         private class ConditionalAccessExpressionVisitor : CSharpSyntaxWalker
         {
             private readonly Stack<bool> _foundConditionalAccess = new();
-            private bool _foundShouldMethodAfterConditionalAccessInCurrentScope;
+            private bool _foundShouldMethodAfterConditionalAccessInSameScope;
 
             private bool FoundConditionalAccessInCurrentScope => _foundConditionalAccess.Any() && _foundConditionalAccess.Peek();
 
-            public bool CodeSmells => _foundShouldMethodAfterConditionalAccessInCurrentScope;
+            public bool CodeSmells => _foundShouldMethodAfterConditionalAccessInSameScope;
 
             public override void VisitConditionalAccessExpression(ConditionalAccessExpressionSyntax node)
             {
@@ -89,7 +89,7 @@ namespace FluentAssertions.Analyzers
             {
                 if (FoundConditionalAccessInCurrentScope && node.Identifier.ValueText == "Should")
                 {
-                    _foundShouldMethodAfterConditionalAccessInCurrentScope = true;
+                    _foundShouldMethodAfterConditionalAccessInSameScope = true;
                 }
             }
         }

--- a/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
+++ b/src/FluentAssertions.Analyzers/Tips/NullConditionalAssertionAnalyzer.cs
@@ -80,6 +80,12 @@ namespace FluentAssertions.Analyzers
                 _foundConditionalAccessInCurrentScope = false;
             }
 
+            public override void VisitArgumentList(ArgumentListSyntax node)
+            {
+                base.DefaultVisit(node);
+                _foundConditionalAccessInCurrentScope = false;
+            }
+
             public override void VisitIdentifierName(IdentifierNameSyntax node)
             {
                 if (_foundConditionalAccessInCurrentScope && node.Identifier.ValueText == "Should")


### PR DESCRIPTION
As noted in #91, the NullConditionalAssertion analyzer gives a false positive for statements like:
`(actual?.MyProperty).Should().Be(expected);`
This PR should fix the above case along with statements where a null-conditional is used in an argument list, for example:
`actual.MyList.Where(obj => obj?.ToString() == null).Count().Should().Be(expected);`