### PR TITLE
Fix missing parenthesis after applying XUnit code fixes

### DIFF
--- a/src/FluentAssertions.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/FluentAssertions.Analyzers.Tests/DiagnosticVerifier.cs
@@ -111,7 +111,7 @@ namespace FluentAssertions.Analyzers.Tests
 
             //after applying all of the code fixes, compare the resulting string to the inputted one
             var actual = GetStringFromDocument(document);
-            ;
+            actual.Should().Be(newSource);
         }
 
         /// <summary>

--- a/src/FluentAssertions.Analyzers.Tests/Tips/XunitTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/XunitTests.cs
@@ -29,6 +29,12 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.True(bool.Parse(\"true\"), \"because it's possible\");",
             /* newAssertion: */ "bool.Parse(\"true\").Should().BeTrue(\"because it's possible\");")]
+        [DataRow(
+            /* oldAssertion: */ "Assert.True(!actual);",
+            /* newAssertion: */ "(!actual).Should().BeTrue();")]
+        [DataRow(
+            /* oldAssertion: */ "Assert.True(actual == false);",
+            /* newAssertion: */ "(actual == false).Should().BeTrue();")]
         [Implemented]
         public void AssertTrue_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertTrueCodeFix, AssertTrueAnalyzer>("bool actual", oldAssertion, newAssertion);
@@ -570,9 +576,11 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsAssignableFrom(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().BeAssignableTo<string>();")]
+#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsAssignableFrom<string>(actual);",
             /* newAssertion: */ "actual.Should().BeAssignableTo<string>();")]
+#endif
         [Implemented]
         public void AssertIsAssignableFrom_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsAssignableFromCodeFix, AssertIsAssignableFromAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);
@@ -592,9 +600,11 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotAssignableFrom(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().NotBeAssignableTo<string>();")]
+#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotAssignableFrom<string>(actual);",
             /* newAssertion: */ "actual.Should().NotBeAssignableTo<string>();")]
+#endif
         [Implemented]
         public void AssertIsNotAssignableFrom_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsNotAssignableFromCodeFix, AssertIsNotAssignableFromAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);
@@ -614,9 +624,11 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsType(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().BeOfType<string>();")]
+#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsType<string>(actual);",
             /* newAssertion: */ "actual.Should().BeOfType<string>();")]
+#endif
         [Implemented]
         public void AssertIsType_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsTypeCodeFix, AssertIsTypeAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);
@@ -636,9 +648,11 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotType(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().NotBeOfType<string>();")]
+#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotType<string>(actual);",
             /* newAssertion: */ "actual.Should().NotBeOfType<string>();")]
+#endif
         [Implemented]
         public void AssertIsNotType_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsNotTypeCodeFix, AssertIsNotTypeAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);

--- a/src/FluentAssertions.Analyzers.Tests/Tips/XunitTests.cs
+++ b/src/FluentAssertions.Analyzers.Tests/Tips/XunitTests.cs
@@ -576,11 +576,9 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsAssignableFrom(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().BeAssignableTo<string>();")]
-#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsAssignableFrom<string>(actual);",
             /* newAssertion: */ "actual.Should().BeAssignableTo<string>();")]
-#endif
         [Implemented]
         public void AssertIsAssignableFrom_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsAssignableFromCodeFix, AssertIsAssignableFromAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);
@@ -600,11 +598,9 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotAssignableFrom(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().NotBeAssignableTo<string>();")]
-#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotAssignableFrom<string>(actual);",
             /* newAssertion: */ "actual.Should().NotBeAssignableTo<string>();")]
-#endif
         [Implemented]
         public void AssertIsNotAssignableFrom_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsNotAssignableFromCodeFix, AssertIsNotAssignableFromAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);
@@ -624,11 +620,9 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsType(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().BeOfType<string>();")]
-#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsType<string>(actual);",
             /* newAssertion: */ "actual.Should().BeOfType<string>();")]
-#endif
         [Implemented]
         public void AssertIsType_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsTypeCodeFix, AssertIsTypeAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);
@@ -648,11 +642,9 @@ namespace FluentAssertions.Analyzers.Tests.Tips
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotType(typeof(string), actual);",
             /* newAssertion: */ "actual.Should().NotBeOfType<string>();")]
-#if TO_BE_FIXED
         [DataRow(
             /* oldAssertion: */ "Assert.IsNotType<string>(actual);",
             /* newAssertion: */ "actual.Should().NotBeOfType<string>();")]
-#endif
         [Implemented]
         public void AssertIsNotType_TestCodeFix(string oldAssertion, string newAssertion)
             => VerifyCSharpFix<AssertIsNotTypeCodeFix, AssertIsNotTypeAnalyzer>("string actual, Type expected", oldAssertion, newAssertion);

--- a/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsAssignableFrom.cs
+++ b/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsAssignableFrom.cs
@@ -60,7 +60,7 @@ public class AssertIsAssignableFromCodeFix : XunitCodeFixProvider
         switch (properties.VisitorName)
         {
             case nameof(AssertIsAssignableFromAnalyzer.AssertIsAssignableFromGenericTypeSyntaxVisitor):
-                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsAssignableFrom", "BeAssignableTo");
+                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsAssignableFrom", "BeAssignableTo", argumentIndex: 0);
             case nameof(AssertIsAssignableFromAnalyzer.AssertIsAssignableFromTypeSyntaxVisitor):
                 var newExpression = RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsAssignableFrom", "BeAssignableTo");
                 return ReplaceTypeOfArgumentWithGenericTypeIfExists(newExpression, "BeAssignableTo");

--- a/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsNotAssignableFrom.cs
+++ b/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsNotAssignableFrom.cs
@@ -60,7 +60,7 @@ public class AssertIsNotAssignableFromCodeFix : XunitCodeFixProvider
         switch (properties.VisitorName)
         {
             case nameof(AssertIsNotAssignableFromAnalyzer.AssertIsNotAssignableFromGenericTypeSyntaxVisitor):
-                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsNotAssignableFrom", "NotBeAssignableTo");
+                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsNotAssignableFrom", "NotBeAssignableTo", argumentIndex: 0);
             case nameof(AssertIsNotAssignableFromAnalyzer.AssertIsNotAssignableFromTypeSyntaxVisitor):
                 var newExpression = RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsNotAssignableFrom", "NotBeAssignableTo");
                 return ReplaceTypeOfArgumentWithGenericTypeIfExists(newExpression, "NotBeAssignableTo");

--- a/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsNotType.cs
+++ b/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsNotType.cs
@@ -60,7 +60,7 @@ public class AssertIsNotTypeCodeFix : XunitCodeFixProvider
         switch (properties.VisitorName)
         {
             case nameof(AssertIsNotTypeAnalyzer.AssertIsNotTypeGenericTypeSyntaxVisitor):
-                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsNotType", "NotBeOfType");
+                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsNotType", "NotBeOfType", argumentIndex: 0);
             case nameof(AssertIsNotTypeAnalyzer.AssertIsNotTypeTypeSyntaxVisitor):
                 var newExpression = RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsNotType", "NotBeOfType");
                 return ReplaceTypeOfArgumentWithGenericTypeIfExists(newExpression, "NotBeOfType");

--- a/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsType.cs
+++ b/src/FluentAssertions.Analyzers/Tips/Xunit/AssertIsType.cs
@@ -60,7 +60,7 @@ public class AssertIsTypeCodeFix : XunitCodeFixProvider
         switch (properties.VisitorName)
         {
             case nameof(AssertIsTypeAnalyzer.AssertIsTypeGenericTypeSyntaxVisitor):
-                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsType", "BeOfType");
+                return RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsType", "BeOfType", argumentIndex: 0);
             case nameof(AssertIsTypeAnalyzer.AssertIsTypeTypeSyntaxVisitor):
                 var newExpression = RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(expression, "IsType", "BeOfType");
                 return ReplaceTypeOfArgumentWithGenericTypeIfExists(newExpression, "BeOfType");

--- a/src/FluentAssertions.Analyzers/Utilities/Expressions.cs
+++ b/src/FluentAssertions.Analyzers/Utilities/Expressions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace FluentAssertions.Analyzers;
@@ -26,16 +27,8 @@ public static class Expressions
     
     public static InvocationExpressionSyntax SubjectShould(ExpressionSyntax subject)
     {
-        if (subject is CastExpressionSyntax or BinaryExpressionSyntax or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax)
-        {
-            return SF.InvocationExpression(
-                SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.ParenthesizedExpression(subject), SF.IdentifierName("Should")),
-                SF.ArgumentList()
-            );
-        }
-
         return SF.InvocationExpression(
-            SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, subject, SF.IdentifierName("Should")),
+            SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.ParenthesizedExpression(subject).WithAdditionalAnnotations(Simplifier.Annotation), SF.IdentifierName("Should")),
             SF.ArgumentList()
         );
     }

--- a/src/FluentAssertions.Analyzers/Utilities/Expressions.cs
+++ b/src/FluentAssertions.Analyzers/Utilities/Expressions.cs
@@ -26,12 +26,12 @@ public static class Expressions
     
     public static InvocationExpressionSyntax SubjectShould(ExpressionSyntax subject)
     {
-        if (subject.IsKind(SyntaxKind.CastExpression))
+        if (subject is CastExpressionSyntax or BinaryExpressionSyntax or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax)
         {
             return SF.InvocationExpression(
                 SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.ParenthesizedExpression(subject), SF.IdentifierName("Should")),
                 SF.ArgumentList()
-            );    
+            );
         }
 
         return SF.InvocationExpression(

--- a/src/FluentAssertions.Analyzers/Utilities/TestingLibraryCodeFixBase.cs
+++ b/src/FluentAssertions.Analyzers/Utilities/TestingLibraryCodeFixBase.cs
@@ -17,16 +17,16 @@ public abstract class TestingLibraryCodeFixBase : FluentAssertionsCodeFixProvide
         return ReplaceIdentifier(newExpression, AssertClassName, Expressions.SubjectShould(rename.Argument.Expression));
     }
 
-    protected ExpressionSyntax RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(ExpressionSyntax expression, string oldName, string newName)
+    protected ExpressionSyntax RenameMethodAndReorderActualExpectedAndReplaceWithSubjectShould(ExpressionSyntax expression, string oldName, string newName, int argumentIndex = 1)
     {
         var rename = NodeReplacement.RenameAndExtractArguments(oldName, newName);
         var newExpression = GetNewExpression(expression, rename);
 
-        var actual = rename.Arguments[1];
+        var actual = rename.Arguments[argumentIndex];
 
         newExpression = ReplaceIdentifier(newExpression, AssertClassName, Expressions.SubjectShould(actual.Expression));
 
-        return GetNewExpression(newExpression, NodeReplacement.WithArguments(newName, rename.Arguments.RemoveAt(1)));
+        return GetNewExpression(newExpression, NodeReplacement.WithArguments(newName, rename.Arguments.RemoveAt(argumentIndex)));
     }
 
     protected ExpressionSyntax ReplaceTypeOfArgumentWithGenericTypeIfExists(ExpressionSyntax expression, string method)


### PR DESCRIPTION
After applying code fixes to transform XUnit asserts to fluent assertions I got some compilation errors. Some parenthesis were missing when the expression tested was complex.

Note:  The tests were not properly testing the code source after the code fix is applied, I re-enabled it but some tests were failing so I added a `'#if TO_BE_FIXED` 