### PR TITLE
Add `.editorconfig` syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ dotnet add package FluentAssertions.Analyzers
 
 You can exclude assertion methods using the `.editorconfig` file:
 
-````
+```ini
 [*.cs]
 ffa_excluded_methods=M:NUnit.Framework.Assert.Fail;M:NUnit.Framework.Assert.Fail(System.String)
-````
+```
 
 ## Getting Started
 


### PR DESCRIPTION
As Microsoft formats `.editorconfig` files like `.ini` files [in markdown](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options), we should probably do the same.

Before:
```
[*.cs]
ffa_excluded_methods=M:NUnit.Framework.Assert.Fail;M:NUnit.Framework.Assert.Fail(System.String)
```
After:
```ini
[*.cs]
ffa_excluded_methods=M:NUnit.Framework.Assert.Fail;M:NUnit.Framework.Assert.Fail(System.String)
```
@Meir017  <img src="https://cdn.mos.cms.futurecdn.net/4iMw3r4FPyuRcgKBtdp6EA.jpg" width=10% />